### PR TITLE
Add instance role attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Simple AWS VMs for testing. Can create multiple VMs using single security group 
 | additional_ebs_blocks | A map where the values are objects with the same attributes as a aws_ebs_volume with the addition of a device_name attribute that is used for attaching it to the instance. | ```map(object({ device_name = string size = optional(number, null) type = optional(string, null) iops = optional(number, null) throughput = optional(number, null) encrypted = optional(bool, null) kms_key_id = optional(bool, null) final_snapshot = optional(bool, null) multi_attach_enabled = optional(bool, null) snapshot_id = optional(string, null) }))``` | `{}` | no |
 | ingress_cidrs | A list of CIDRs to allow incoming traffic from. | `list(string)` | n/a | yes |
 | name_prefix | A prefix to insert in the created resources' names. | `string` | `""` | no |
+| policy_arns | A list of policy arns to attach to an instance role. | `list(string)` | `[]` | no |
 | root_volume_size | The size of the root volume | `number` | `20` | no |
 | subnet_id | The Id of the AWS subnet in which to create the VM. | `string` | n/a | yes |
 | vm_count | The number of VMs to create. | `number` | `1` | no |
@@ -38,12 +39,16 @@ Simple AWS VMs for testing. Can create multiple VMs using single security group 
 | Name | Type |
 |------|------|
 | aws_ebs_volume.this | resource |
+| aws_iam_instance_profile.this | resource |
+| aws_iam_role.this | resource |
+| aws_iam_role_policy_attachment.this | resource |
 | aws_instance.aws_vm_dev | resource |
 | aws_security_group.aws_vm_dev | resource |
 | aws_security_group_rule.allow_all_egress | resource |
 | aws_security_group_rule.allow_ingress | resource |
 | aws_security_group_rule.allow_ingress_sg | resource |
 | aws_volume_attachment.this | resource |
+| aws_iam_policy_document.instance_assume_role_policy | data source |
 | aws_subnet.this | data source |
 
 ## Documentation

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ data "aws_iam_policy_document" "instance_assume_role_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "this" {
-  for_each   = var.policy_arns
+  for_each   = toset(var.policy_arns)
   role       = aws_iam_role.this.name
   policy_arn = each.value
 }

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,8 @@ data "aws_iam_policy_document" "instance_assume_role_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "this" {
-  for_each   = toset(var.policy_arns)
+  for_each   = var.policy_arns
   role       = aws_iam_role.this.name
-  policy_arn = each.value
+  policy_arn = each.valuestatus
+  
 }

--- a/main.tf
+++ b/main.tf
@@ -76,6 +76,5 @@ data "aws_iam_policy_document" "instance_assume_role_policy" {
 resource "aws_iam_role_policy_attachment" "this" {
   for_each   = var.policy_arns
   role       = aws_iam_role.this.name
-  policy_arn = each.valuestatus
-  
+  policy_arn = each.value
 }

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_instance" "aws_vm_dev" {
   vpc_security_group_ids      = [aws_security_group.aws_vm_dev.id]
   subnet_id                   = var.subnet_id
   associate_public_ip_address = true
-  iam_instance_profile        = aws_iam_instance_profile.this.arn
+  iam_instance_profile        = aws_iam_instance_profile.this.name
   user_data_base64            = var.vm_user_data_base64
 
   root_block_device {

--- a/variables.tf
+++ b/variables.tf
@@ -81,7 +81,7 @@ variable "additional_ebs_blocks" {
 }
 
 variable "policy_arns" {
-  type        = list(string)
-  description = "A list of policy arns to attach to an instance role."
-  default = []
+  type        = map(string)
+  description = "A map where the keys are arbitrary identifiers and the values are policy arns to attach to an instance role."
+  default = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -79,3 +79,9 @@ variable "additional_ebs_blocks" {
     error_message = "The map kyes must not contain '+' character."
   }
 }
+
+variable "policy_arns" {
+  type        = list(string)
+  description = "A list of policy arns to attach to an instance role."
+  default = []
+}


### PR DESCRIPTION
Allow for user to provide AWS policy ARNs which will be attached to a role attached to the EC2 instances.